### PR TITLE
Cleanup README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,28 +5,8 @@
 .. image:: https://travis-ci.org/keitaroinc/ckanext-visualize.svg?branch=master
     :target: https://travis-ci.org/keitaroinc/ckanext-visualize
 
-.. image:: https://coveralls.io/repos/keitaroinc/ckanext-visualize/badge.svg
-  :target: https://coveralls.io/r/keitaroinc/ckanext-visualize
-
-.. image:: https://pypip.in/download/ckanext-visualize/badge.svg
-    :target: https://pypi.python.org/pypi//ckanext-visualize/
-    :alt: Downloads
-
-.. image:: https://pypip.in/version/ckanext-visualize/badge.svg
-    :target: https://pypi.python.org/pypi/ckanext-visualize/
-    :alt: Latest Version
-
-.. image:: https://pypip.in/py_versions/ckanext-visualize/badge.svg
-    :target: https://pypi.python.org/pypi/ckanext-visualize/
-    :alt: Supported Python versions
-
-.. image:: https://pypip.in/status/ckanext-visualize/badge.svg
-    :target: https://pypi.python.org/pypi/ckanext-visualize/
-    :alt: Development Status
-
-.. image:: https://pypip.in/license/ckanext-visualize/badge.svg
-    :target: https://pypi.python.org/pypi/ckanext-visualize/
-    :alt: License
+.. image:: https://coveralls.io/repos/github/keitaroinc/ckanext-visualize/badge.svg
+    :target: https://coveralls.io/github/keitaroinc/ckanext-visualize
 
 =============
 ckanext-visualize
@@ -36,13 +16,14 @@ ckanext-visualize
    What does it do? What features does it have?
    Consider including some screenshots or embedding a video!
 
+CKAN extension which allows users to easily visualize data that's in DataStore
+using a chart.
 
 ------------
 Requirements
 ------------
 
-For example, you might want to mention here which versions of CKAN this
-extension works with.
+This extension is developed and tested on CKAN 2.8
 
 
 ------------
@@ -72,17 +53,6 @@ To install ckanext-visualize:
      sudo service apache2 reload
 
 
----------------
-Config Settings
----------------
-
-Document any optional config settings here. For example::
-
-    # The minimum number of hours to wait before re-checking a resource
-    # (optional, default: 24).
-    ckanext.visualize.some_setting = some_default_value
-
-
 ------------------------
 Development Installation
 ------------------------
@@ -108,59 +78,3 @@ To run the tests and produce a coverage report, first make sure you have
 coverage installed in your virtualenv (``pip install coverage``) then run::
 
     nosetests --nologcapture --with-pylons=test.ini --with-coverage --cover-package=ckanext.visualize --cover-inclusive --cover-erase --cover-tests
-
-
----------------------------------
-Registering ckanext-visualize on PyPI
----------------------------------
-
-ckanext-visualize should be availabe on PyPI as
-https://pypi.python.org/pypi/ckanext-visualize. If that link doesn't work, then
-you can register the project on PyPI for the first time by following these
-steps:
-
-1. Create a source distribution of the project::
-
-     python setup.py sdist
-
-2. Register the project::
-
-     python setup.py register
-
-3. Upload the source distribution to PyPI::
-
-     python setup.py sdist upload
-
-4. Tag the first release of the project on GitHub with the version number from
-   the ``setup.py`` file. For example if the version number in ``setup.py`` is
-   0.0.1 then do::
-
-       git tag 0.0.1
-       git push --tags
-
-
-----------------------------------------
-Releasing a New Version of ckanext-visualize
-----------------------------------------
-
-ckanext-visualize is availabe on PyPI as https://pypi.python.org/pypi/ckanext-visualize.
-To publish a new version to PyPI follow these steps:
-
-1. Update the version number in the ``setup.py`` file.
-   See `PEP 440 <http://legacy.python.org/dev/peps/pep-0440/#public-version-identifiers>`_
-   for how to choose version numbers.
-
-2. Create a source distribution of the new version::
-
-     python setup.py sdist
-
-3. Upload the source distribution to PyPI::
-
-     python setup.py sdist upload
-
-4. Tag the new release of the project on GitHub with the version number from
-   the ``setup.py`` file. For example if the version number in ``setup.py`` is
-   0.0.2 then do::
-
-       git tag 0.0.2
-       git push --tags


### PR DESCRIPTION
This PR cleans up the README with the following changes:

- Fixed Coveralls badge
- Removed badges for pypip because the service does not exist anymore
- Added description and requirements
- Removed docs for registering the extension on PyPI, releasing a new version and config settings