### PR TITLE
Color code columns

### DIFF
--- a/ckanext/visualize/fanstatic/js/modules/visualize-data.js
+++ b/ckanext/visualize/fanstatic/js/modules/visualize-data.js
@@ -61,16 +61,7 @@ ckan.module('visualize-data', function($) {
           {
             label: 'Some dataset label',
             data: [],
-            backgroundColor: [
-              '#332288',
-              '#117733',
-              '#44AA99',
-              '#88CCEE',
-              '#DDCC77',
-              '#CC6677',
-              '#AA4499',
-              '#882255'
-            ]
+            backgroundColor: '#332288'
           }
         ]
       };

--- a/ckanext/visualize/helpers.py
+++ b/ckanext/visualize/helpers.py
@@ -11,7 +11,7 @@ def get_fields_without_id(resource_id):
     :rtype: list """
 
     fields = _get_fields(resource_id)
-    return [{'value': v['id']} for v in fields if v['id'] != '_id']
+    return [{'value': v['id'], 'type': v['type']} for v in fields if v['id'] != '_id']
 
 
 def _get_fields(resource_id):

--- a/ckanext/visualize/templates/snippets/visualize_view_show.html
+++ b/ckanext/visualize/templates/snippets/visualize_view_show.html
@@ -22,8 +22,27 @@
                 <section class="col-md-10">
                     <ul id="all-columns" class="list-group group-items-select list-group-horizontal">
                         {% for field in fields %}
+                            {% if field.type == 'text' %}
+                                {% set column_color = '#332288' %}
+                            {% elif field.type == 'numeric' %}
+                                {% set column_color = '#117733' %}
+                            {% elif field.type == 'date' %}
+                                {% set column_color = '#44AA99' %}
+                            {% elif field.type == 'time' %}
+                                {% set column_color = '#88CCEE' %}
+                            {% elif field.type == 'timestamp' %}
+                                {% set column_color = '#DDCC77' %}
+                            {% elif field.type == 'bool' %}
+                                {% set column_color = '#CC6677' %}
+                            {% elif field.type == 'int' %}
+                                {% set column_color = '#AA4499' %}
+                            {% elif field.type == 'float' %}
+                                {% set column_color = '#882255' %}
+                            {% else %}
+                                {% set column_color = '#332288' %}
+                            {% endif %}
                             <li class="list-group-item column" data-column="{{ field.value }}">
-                                <span class="badge-pill color-secondary column-pill">{{ field.value }}</span>
+                                <span class="badge-pill column-pill" style="background-color: {{ column_color }};">{{ field.value }}</span>
                             </li>
                         {% endfor %}
                     </ul>

--- a/ckanext/visualize/tests/test_view.py
+++ b/ckanext/visualize/tests/test_view.py
@@ -79,7 +79,7 @@ class TestVisualizeView(helpers.FunctionalTestBase):
         assert result == {
             'resource': {'id': resource.get('id')},
             'resource_view': {},
-            'fields': [{'value': u'Age'}, {'value': u'Name'}],
+            'fields': [{'value': u'Age', 'type': 'numeric'}, {'value': u'Name', 'type': 'text'}],
         }
 
     def test_view_template(self):


### PR DESCRIPTION
This PR implements logic to use different colors for columns, to allow easier distinction between the different types of data, such as: text, numeric, date, etc.

Color values are used from the default color palette.

In this PR I also changed the background color for bar chart to be the default color.