### PR TITLE
Change tab title in Admin settings page

### DIFF
--- a/ckanext/visualize/templates/admin/base.html
+++ b/ckanext/visualize/templates/admin/base.html
@@ -2,5 +2,5 @@
 
 {% block content_primary_nav %}
   {{ super() }}
-  {{ h.build_nav_icon('ckanadmin_visualize_data', _('Visualize data')) }}
+  {{ h.build_nav_icon('ckanadmin_visualize_data', _('Visualize')) }}
 {% endblock %}

--- a/ckanext/visualize/templates/admin/visualize_data.html
+++ b/ckanext/visualize/templates/admin/visualize_data.html
@@ -17,7 +17,7 @@
   <div class="module module-narrow module-shallow">
     <h2 class="module-heading">
       <i class="fa fa-info-circle"></i>
-      {{ _('Visualize data options') }}
+      {{ _('Visualize options') }}
     </h2>
     <div class="module-content">
       {% block admin_form_help %}

--- a/ckanext/visualize/tests/test_controllers.py
+++ b/ckanext/visualize/tests/test_controllers.py
@@ -143,4 +143,4 @@ class TestAdminController(helpers.FunctionalTestBase):
         route = url_for(controller=controller, action=action)
         response = app.get(url=route, extra_environ=env)
 
-        assert 'Visualize data' in response.body
+        assert 'Visualize' in response.body


### PR DESCRIPTION
This PR changes the name of the title of the tab for the Admin settings page, to reflect the name of the extension.