### PR TITLE
Persist pre-defined charts

### DIFF
--- a/ckanext/visualize/fanstatic/js/modules/visualize-data.js
+++ b/ckanext/visualize/fanstatic/js/modules/visualize-data.js
@@ -33,6 +33,9 @@ ckan.module('visualize-data', function($) {
   var xAxisList = $('.x-axis-list');
   var yAxisList = $('.y-axis-list');
   var chartIcon = $('#chart-icon');
+  var xAxisHiddenInput = $('input[name="visualize_x_axis"]');
+  var yAxisHiddenInput = $('input[name="visualize_y_axis"]');
+  var colorAttrHiddenInput = $('input[name="visualize_color_attr"]');
   var lastxAxisEvent;
   var lastyAxisEvent;
   var lastColorAttrEvent;
@@ -344,7 +347,6 @@ ckan.module('visualize-data', function($) {
             chartContainer.removeClass('hidden');
             noChartContainer.addClass('hidden');
 
-            var xAxisHiddenInput = $('input[name="visualize_x_axis"]');
             xAxisHiddenInput.val(currentxAxis);
           } else if (to === 'y-axis') {
             lastyAxisEvent = { item: evt.item, to: evt.to };
@@ -424,7 +426,6 @@ ckan.module('visualize-data', function($) {
             chartContainer.removeClass('hidden');
             noChartContainer.addClass('hidden');
 
-            var yAxisHiddenInput = $('input[name="visualize_y_axis"]');
             yAxisHiddenInput.val(currentyAxis);
           } else if (to === 'color-attr') {
             currentColorAttr = column;
@@ -555,7 +556,6 @@ ckan.module('visualize-data', function($) {
               }
             }
 
-            var colorAttrHiddenInput = $('input[name="visualize_color_attr"]');
             colorAttrHiddenInput.val(column);
 
             chart.destroy();
@@ -578,7 +578,6 @@ ckan.module('visualize-data', function($) {
               chartContainer.addClass('hidden');
               noChartContainer.removeClass('hidden');
             }
-            var xAxisHiddenInput = $('input[name="visualize_x_axis"]');
             xAxisHiddenInput.val('');
           } else if (from === 'y-axis') {
             chartData.datasets[0].data = [];
@@ -588,7 +587,6 @@ ckan.module('visualize-data', function($) {
               chartContainer.addClass('hidden');
               noChartContainer.removeClass('hidden');
             }
-            var yAxisHiddenInput = $('input[name="visualize_y_axis"]');
             yAxisHiddenInput.val('');
           } else if (from === 'color-attr') {
             chartData = {
@@ -616,7 +614,6 @@ ckan.module('visualize-data', function($) {
               onColumnAdd(lastyAxisEvent);
             }
 
-            var colorAttrHiddenInput = $('input[name="visualize_color_attr"]');
             colorAttrHiddenInput.val('');
           }
           currentChartType =
@@ -626,6 +623,9 @@ ckan.module('visualize-data', function($) {
         }
       }
 
+      this.drawChartFromPredefinedView(onColumnAdd);
+    },
+    drawChartFromPredefinedView: function(onColumnAdd) {
       var xAxisColumn = this.options.resourceView.visualize_x_axis;
       var yAxisColumn = this.options.resourceView.visualize_y_axis;
       var colorAttr = this.options.resourceView.visualize_color_attr;

--- a/ckanext/visualize/plugin.py
+++ b/ckanext/visualize/plugin.py
@@ -36,7 +36,11 @@ class VisualizePlugin(plugins.SingletonPlugin):
     # IResourceView
 
     def info(self):
-        schema = {}
+        schema = {
+            'visualize_x_axis': [ignore_missing],
+            'visualize_y_axis': [ignore_missing],
+            'visualize_color_attr': [ignore_missing],
+        }
 
         return {
             'name': 'visualize',
@@ -57,13 +61,15 @@ class VisualizePlugin(plugins.SingletonPlugin):
         remap_keys = list(fields)
         remap_keys.insert(0, {'value': ''})
 
+        print 'resource_view', resource_view
+
         return {
             'resource': resource,
             'resource_view': resource_view,
             'fields': fields,
             'bar_chart_icon': config.get('bar_chart_icon') or '/base/images/Bar-symbol.png',
             'line_chart_icon': config.get('line_chart_icon') or '/base/images/Line-symbol.png',
-            'point_chart_icon': config.get('point_chart_icon') or '/base/images/Point-symbol.png',
+            'point_chart_icon': config.get('point_chart_icon') or '/base/images/Point-symbol.png'
         }
 
     def view_template(self, context, data_dict):

--- a/ckanext/visualize/plugin.py
+++ b/ckanext/visualize/plugin.py
@@ -61,8 +61,6 @@ class VisualizePlugin(plugins.SingletonPlugin):
         remap_keys = list(fields)
         remap_keys.insert(0, {'value': ''})
 
-        print 'resource_view', resource_view
-
         return {
             'resource': resource,
             'resource_view': resource_view,

--- a/ckanext/visualize/templates/package/edit_view.html
+++ b/ckanext/visualize/templates/package/edit_view.html
@@ -1,0 +1,15 @@
+{% ckan_extends %}
+
+{% block form %}
+  <form class="dataset-form dataset-resource-form" method="post" data-module="basic-form resource-form">
+    {% include 'package/snippets/view_form.html' %}
+    <input type="hidden" name="visualize_x_axis" />
+    <input type="hidden" name="visualize_y_axis" />
+    <input type="hidden" name="visualize_color_attr" />
+    <div class="form-actions">
+      <button class="btn btn-danger pull-left" name="delete" value="Delete"> {{ _('Delete') }} </button>
+      <button class="btn btn-default {% if not h.resource_view_display_preview(data) %}hide{%endif%}" name="preview" value="True" type="submit">{{ _('Preview') }}</button>
+      <button class="btn btn-primary" name="save" value="Save" type="submit">{{ _('Update') }}</button>
+    </div>
+  </form>
+{% endblock %}

--- a/ckanext/visualize/templates/package/new_view.html
+++ b/ckanext/visualize/templates/package/new_view.html
@@ -1,0 +1,23 @@
+{% ckan_extends %}
+
+{% block form %}
+  {% if resource_view.view_type == 'recline_view' and not datastore_available %}
+    <p class="text-info">
+      <i class="fa fa-info-circle"></i>
+      {% trans %}
+      Data Explorer views may be slow and unreliable unless the DataStore extension is enabled. For more information, please see the <a href='http://docs.ckan.org/en/latest/maintaining/data-viewer.html#viewing-structured-data-the-data-explorer' target='_blank'>Data Explorer documentation</a>.
+      {% endtrans %}
+    </p>
+  {% endif %}
+
+  <form class="dataset-form dataset-resource-form" method="post" data-module="basic-form resource-form">
+    {% include 'package/snippets/view_form.html' %}
+    <input type="hidden" name="visualize_x_axis" />
+    <input type="hidden" name="visualize_y_axis" />
+    <input type="hidden" name="visualize_color_attr" />
+    <div class="form-actions">
+        <button class="btn btn-default {% if not h.resource_view_display_preview(data) %}hide{%endif%}" name="preview" value="True" type="submit">{{ _('Preview') }}</button>
+        <button class="btn btn-primary" name="save" value="Save" type="submit">{% block save_button_text %}{{ _('Add') }}{% endblock %}</button>
+    </div>
+  </form>
+{% endblock %}

--- a/ckanext/visualize/tests/test_view.py
+++ b/ckanext/visualize/tests/test_view.py
@@ -4,6 +4,8 @@ from ckan.plugins import toolkit
 
 from ckanext.visualize.plugin import VisualizePlugin
 
+ignore_missing = p.toolkit.get_validator('ignore_missing')
+
 
 class TestVisualizeView(helpers.FunctionalTestBase):
 
@@ -35,7 +37,11 @@ class TestVisualizeView(helpers.FunctionalTestBase):
             'icon': 'bar-chart-o',
             'filterable': True,
             'iframed': False,
-            'schema': {}
+            'schema': {
+                'visualize_x_axis': [ignore_missing],
+                'visualize_y_axis': [ignore_missing],
+                'visualize_color_attr': [ignore_missing],
+            }
         }
 
     def test_can_view(self):


### PR DESCRIPTION
This PR will persist charts that are created as a view. It also fixes some bugs discovered during the testing, most of them related to the order of which the columns are dragged.