### PR TITLE
Fix issue when removing a color after Set default

### DIFF
--- a/ckanext/visualize/fanstatic/js/modules/visualize-colors-settings-reset.js
+++ b/ckanext/visualize/fanstatic/js/modules/visualize-colors-settings-reset.js
@@ -38,6 +38,7 @@ ckan.module('visualize-colors-settings-reset', function($) {
               .replace(new RegExp('\\$color\\$', 'g'), color)
           );
         });
+        window.ckan.module.initializeElement(colorsContainer[0]);
       });
     }
   };


### PR DESCRIPTION
This PR fixes an issue in the admin config page where removing a color was not working after pressing the "Set default" button.