### PR TITLE
Fix responsive design issues

### DIFF
--- a/ckanext/visualize/fanstatic/css/data_viewer.css
+++ b/ckanext/visualize/fanstatic/css/data_viewer.css
@@ -1,4 +1,4 @@
 body {
     background: none;
-    margin-right: 15px;
+    margin: 15px;
 }

--- a/ckanext/visualize/fanstatic/css/main.css
+++ b/ckanext/visualize/fanstatic/css/main.css
@@ -156,7 +156,6 @@
 }
 
 .img-icon {
-  width: 100%;
   height: 15rem;
   object-fit: contain;
   border-radius: 4px;

--- a/ckanext/visualize/fanstatic/css/main.css
+++ b/ckanext/visualize/fanstatic/css/main.css
@@ -19,6 +19,10 @@
   border: none;
 }
 
+.panel-visualize .img-responsive {
+  margin: auto;
+}
+
 .desc-muted {
   font-weight: 400;
 }


### PR DESCRIPTION
This PR fixes two responsive design issues on the http://127.0.0.1:5000/visualize_data frame page:

- <body> margin was only set to the right side, now it is set to all sides
- the chart icon was not aligned to center when image placeholder was larger in width