### PR TITLE
IE11 improvements

### DIFF
--- a/ckanext/visualize/fanstatic/css/main.css
+++ b/ckanext/visualize/fanstatic/css/main.css
@@ -250,9 +250,22 @@ input[type='color']::-webkit-color-swatch {
   .panel-icon .controls {
     text-align: center;
   }
+
+  /* Fix IE flexbox alignment issues */
+  _:-ms-fullscreen,
+  :root .axis-title {
+    left: 40%;
+  }
 }
 
 @media (max-width: 992px) {
+
+  /* Fix IE flexbox alignment issues */
+  _:-ms-fullscreen,
+  :root .axis-title {
+    left: 45%;
+  }
+
   .figure-wrapper {
     margin-bottom: 2rem;
   }

--- a/ckanext/visualize/fanstatic/css/main.css
+++ b/ckanext/visualize/fanstatic/css/main.css
@@ -99,6 +99,8 @@
 }
 
 .column-pill {
+  cursor: move;
+  /* ^ fallback for Internet Explorer */
   cursor: grab;
 }
 

--- a/ckanext/visualize/templates/snippets/visualize_view_show.html
+++ b/ckanext/visualize/templates/snippets/visualize_view_show.html
@@ -96,17 +96,15 @@
             </div>
           </div>
           <div class="panel panel-default">
-            <div class="panel-body group-items-drop">
-              <div class="drop-list-group">
-                <div id="x-axis" class="axis-list x-axis-list">
-                  <small class="axis-title">{{ _('X-axis') }}</small>
-                </div>
-                <div id="y-axis" class="axis-list y-axis-list">
-                  <small class="axis-title">{{ _('Y-axis') }}</small>
-                </div>
-                <div id="color-attr" class="axis-list color-attr-list">
-                  <small class="axis-title">{{ _('Color') }}</small>
-                </div>
+            <div class="panel-body group-items-drop drop-list-group">
+              <div id="x-axis" class="axis-list x-axis-list">
+                <small class="axis-title">{{ _('X-axis') }}</small>
+              </div>
+              <div id="y-axis" class="axis-list y-axis-list">
+                <small class="axis-title">{{ _('Y-axis') }}</small>
+              </div>
+              <div id="color-attr" class="axis-list color-attr-list">
+                <small class="axis-title">{{ _('Color') }}</small>
               </div>
             </div>
           </div>

--- a/ckanext/visualize/templates/snippets/visualize_view_show.html
+++ b/ckanext/visualize/templates/snippets/visualize_view_show.html
@@ -105,7 +105,7 @@
                   <small class="axis-title">{{ _('Y-axis') }}</small>
                 </div>
                 <div id="color-attr" class="axis-list color-attr-list">
-                  <small class="axis-title">{{ _('color') }}</small>
+                  <small class="axis-title">{{ _('Color') }}</small>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
This PR fixes the following two issue in Internet Explorer 11:

- Pill placeholder labels are not centered
- The mouse pointer is not changed on pill hover