### PR TITLE
Fix X-axis start point

### DIFF
--- a/ckanext/visualize/fanstatic/js/modules/visualize-data.js
+++ b/ckanext/visualize/fanstatic/js/modules/visualize-data.js
@@ -74,7 +74,13 @@ ckan.module('visualize-data', function($) {
             }
           }
         ],
-        xAxes: [{}]
+        xAxes: [
+          {
+            ticks: {
+              beginAtZero: true
+            }
+          }
+        ]
       },
       legend: {
         position: 'bottom'


### PR DESCRIPTION
This PR introduces the following changes:
- Force start at 0 for X-axis in visualize-data.js when values are greater than 0.

Testing instructions:
1. Upload a resource
2. Go to Visualize data page
3. Choose pills for X and Y axis:
- Make sure the chosen pills represent numbers
- Make sure that the X-values are greater than 0
4. Drag & drop pills accordingly

The applied changes should generate a graph whose X-axis values start from 0.