### PR TITLE
Remove label from legend when no colors are selected

### DIFF
--- a/ckanext/visualize/fanstatic/js/modules/visualize-data.js
+++ b/ckanext/visualize/fanstatic/js/modules/visualize-data.js
@@ -20,7 +20,7 @@ ckan.module('visualize-data', function($) {
     labels: [],
     datasets: [
       {
-        label: 'Some dataset label',
+        label: '',
         data: [],
         fill: false
       }
@@ -600,7 +600,7 @@ ckan.module('visualize-data', function($) {
               labels: [],
               datasets: [
                 {
-                  label: 'Some dataset label',
+                  label: '',
                   data: [],
                   fill: false
                 }

--- a/ckanext/visualize/fanstatic/js/modules/visualize-data.js
+++ b/ckanext/visualize/fanstatic/js/modules/visualize-data.js
@@ -42,7 +42,6 @@ ckan.module('visualize-data', function($) {
   var barChartIcon;
   var lineChartIcon;
   var pointChartIcon;
-
   function getUniqueValues(arr) {
     if (isIE()) {
       var a = [];
@@ -77,7 +76,8 @@ ckan.module('visualize-data', function($) {
         xAxes: [{}]
       },
       legend: {
-        position: 'bottom'
+        position: 'bottom',
+        display: false       
       }
     };
     chartData.datasets[0].backgroundColor = colorPalette[0];
@@ -86,13 +86,17 @@ ckan.module('visualize-data', function($) {
     if (currentColorAttr && currentChartType === CHART_TYPES.BAR) {
       chartOptions.scales.yAxes[0].stacked = true;
       chartOptions.scales.xAxes[0].stacked = true;
+      chartOptions.legend.display = true;
     }
-
+    if(currentColorAttr && currentChartType === CHART_TYPES.LINE) {
+      chartOptions.legend.display = true;
+    }
     chart = new Chart(ctx, {
       type: currentChartType,
       data: chartData,
       options: chartOptions
     });
+    
     updateChartIcon();
   }
 
@@ -478,7 +482,6 @@ ckan.module('visualize-data', function($) {
                       colorsIndex++;
                     }
                   }
-
                   chartData.datasets.push({
                     label: label,
                     backgroundColor: currentColor,
@@ -541,7 +544,6 @@ ckan.module('visualize-data', function($) {
 
                 chartData.datasets = [];
                 var uniqueLabels = getUniqueValues(columns[currentxAxis]);
-
                 chartData.labels = uniqueLabels;
                 var currentIndex = 0;
 


### PR DESCRIPTION
This PR introduces the following changes:
- Removed "Some dataset label" legend when no colors are selected.

Testing instructions:
1. Upload a resource
2. Go to Visualize data page
3. Choose pills for X and/or Y axis
4. Drag & drop pills accordingly (The legend is not displayed)
5. Drag & drop a third pill into the color field (The legend is displayed)
