### PR TITLE
Message for non supported graph types

### DIFF
--- a/ckanext/visualize/fanstatic/css/main.css
+++ b/ckanext/visualize/fanstatic/css/main.css
@@ -82,6 +82,11 @@ _:-ms-fullscreen,
   padding: 1rem;
 }
 
+.chart-unsupported {
+  position: absolute;
+  opacity: 0.9;
+}
+
 .group-items-select {}
 
 .panel-wrap-flex .group-items-select.panel-body {

--- a/ckanext/visualize/fanstatic/js/modules/visualize-data.js
+++ b/ckanext/visualize/fanstatic/js/modules/visualize-data.js
@@ -85,7 +85,7 @@ ckan.module('visualize-data', function($) {
       },
       legend: {
         position: 'bottom',
-        display: false
+        display: true
       }
     };
     chartData.datasets[0].backgroundColor = colorPalette[0];
@@ -94,11 +94,12 @@ ckan.module('visualize-data', function($) {
     if (currentColorAttr && currentChartType === CHART_TYPES.BAR) {
       chartOptions.scales.yAxes[0].stacked = true;
       chartOptions.scales.xAxes[0].stacked = true;
-      chartOptions.legend.display = true;
     }
-    if(currentColorAttr && currentChartType === CHART_TYPES.LINE) {
-      chartOptions.legend.display = true;
+
+    if(!currentColorAttr || (currentColorAttr && currentxAxis && !currentyAxis) || (currentColorAttr && !currentxAxis && currentyAxis)) {
+      chartOptions.legend.display = false;
     }
+
     chart = new Chart(ctx, {
       type: currentChartType,
       data: chartData,
@@ -330,7 +331,6 @@ ckan.module('visualize-data', function($) {
         }
         if (columns[column] && isSupported) {
           if (to === 'x-axis') {
-            lastxAxisEvent = { item: evt.item, to: evt.to };
             currentxAxisType = columnType;
             currentxAxis = column;
             currentChartType =
@@ -413,7 +413,6 @@ ckan.module('visualize-data', function($) {
 
             xAxisHiddenInput.val(currentxAxis);
           } else if (to === 'y-axis') {
-            lastyAxisEvent = { item: evt.item, to: evt.to };
             currentyAxisType = columnType;
             currentyAxis = column;
             currentChartType =

--- a/ckanext/visualize/fanstatic/js/modules/visualize-data.js
+++ b/ckanext/visualize/fanstatic/js/modules/visualize-data.js
@@ -31,6 +31,8 @@ ckan.module('visualize-data', function($) {
   var chartContainer = $('.chart-container');
   var noChartContainer = $('.no-chart-container');
   var xAxisList = $('.x-axis-list');
+  var unsupportedContainer = $('.unsupported');
+  var isSupported = true;
   var yAxisList = $('.y-axis-list');
   var chartIcon = $('#chart-icon');
   var xAxisHiddenInput = $('input[name="visualize_x_axis"]');
@@ -291,7 +293,40 @@ ckan.module('visualize-data', function($) {
         var column = item.attr('data-column');
         var columnType = item.attr('data-column-type');
         var to = $(evt.to).attr('id');
-        if (columns[column]) {
+        unsupportedContainer.addClass('hidden');
+        isSupported = true;
+        if(to === 'y-axis') {
+          currentyAxisType = columnType;
+          currentyAxis = column;
+            
+          if (
+            (currentxAxisType === "text" && currentyAxisType === "text") ||
+            (currentxAxisType === ("timestamp" || "date") &&
+              currentyAxisType === ("timestamp" || "date")) ||
+            (currentxAxisType === "text" &&
+              currentyAxisType === ("timestamp" || "date")) ||
+            (currentxAxisType === ("timestamp" || "date") &&
+              currentyAxisType === "text") ||
+            (currentxAxisType === "numeric" &&
+              currentyAxisType === ("timestamp" || "date"))
+          ) {
+            chartContainer.addClass('hidden');
+            noChartContainer.removeClass('hidden');
+            unsupportedContainer.removeClass('hidden');
+            isSupported = false;
+            // chartData.labels = [];
+            // currentxAxisType = null;
+            // currentxAxis = null;
+            // chartData.datasets[0].data = [];
+            // currentyAxisType = null;
+            // currentyAxis = null;
+            // xAxisHiddenInput.val('');
+            // yAxisHiddenInput.val('');
+            // chart.destroy();
+            // initChart();
+            }            
+        }
+        if (columns[column] && isSupported) {
           if (to === 'x-axis') {
             lastxAxisEvent = { item: evt.item, to: evt.to };
             currentxAxisType = columnType;
@@ -379,23 +414,6 @@ ckan.module('visualize-data', function($) {
             lastyAxisEvent = { item: evt.item, to: evt.to };
             currentyAxisType = columnType;
             currentyAxis = column;
-            if (
-              (currentxAxisType === "text" && currentyAxisType === "text") ||
-              (currentxAxisType === ("timestamp" || "date") &&
-                currentyAxisType === ("timestamp" || "date")) ||
-              (currentxAxisType === "text" &&
-                currentyAxisType === ("timestamp" || "date")) ||
-              (currentxAxisType === ("timestamp" || "date") &&
-                currentyAxisType === "text") ||
-              (currentxAxisType === "numeric" &&
-                currentyAxisType === ("timestamp" || "date"))
-            ) {
-              alert("The chosen graph type is not supported! Please choose other values for X or Y axis.");
-              console.log(item);
-              currentyAxis = null;
-              currentyAxisType = null;
-              item.remove();
-            }
             currentChartType =
               getChartType(currentxAxisType, currentyAxisType) || 'bar';
 
@@ -601,6 +619,7 @@ ckan.module('visualize-data', function($) {
         var item = $(evt.item);
         var column = item.attr('data-column');
         var from = $(evt.from).attr('id');
+        isSupported = true;
         if (columns[column]) {
           if (from === 'x-axis') {
             chartData.labels = [];

--- a/ckanext/visualize/fanstatic/js/modules/visualize-data.js
+++ b/ckanext/visualize/fanstatic/js/modules/visualize-data.js
@@ -30,7 +30,7 @@ ckan.module('visualize-data', function($) {
   var ctx = document.getElementById('chart-canvas').getContext('2d');
   var chartContainer = $('.chart-container');
   var noChartContainer = $('.no-chart-container');
-  var unsupportedContainer = $('.unsupported');
+  var unsupportedContainer = $('.chart-unsupported');
   var isSupported = true;
   var xAxisList = $('.x-axis-list');
   var yAxisList = $('.y-axis-list');
@@ -85,7 +85,7 @@ ckan.module('visualize-data', function($) {
       },
       legend: {
         position: 'bottom',
-        display: false   
+        display: false
       }
     };
     chartData.datasets[0].backgroundColor = colorPalette[0];
@@ -104,7 +104,7 @@ ckan.module('visualize-data', function($) {
       data: chartData,
       options: chartOptions
     });
-    
+
     updateChartIcon();
   }
 
@@ -315,14 +315,14 @@ ckan.module('visualize-data', function($) {
         if(to === 'y-axis') {
           lastyAxisEvent = { item: evt.item, to: evt.to };
           currentyAxisType = columnType;
-          currentyAxis = column;                   
+          currentyAxis = column;
         }
         if(to === 'x-axis') {
           lastxAxisEvent = { item: evt.item, to: evt.to };
           currentxAxisType = columnType;
-          currentxAxis = column;            
+          currentxAxis = column;
         }
-        isSupported = isSupportedGraphType(currentxAxisType, currentyAxisType);   
+        isSupported = isSupportedGraphType(currentxAxisType, currentyAxisType);
         if(!isSupported) {
           chartContainer.addClass('hidden');
           noChartContainer.removeClass('hidden');

--- a/ckanext/visualize/fanstatic/js/modules/visualize-data.js
+++ b/ckanext/visualize/fanstatic/js/modules/visualize-data.js
@@ -313,10 +313,12 @@ ckan.module('visualize-data', function($) {
         unsupportedContainer.addClass('hidden');
         isSupported = true;
         if(to === 'y-axis') {
+          lastyAxisEvent = { item: evt.item, to: evt.to };
           currentyAxisType = columnType;
           currentyAxis = column;                   
         }
         if(to === 'x-axis') {
+          lastxAxisEvent = { item: evt.item, to: evt.to };
           currentxAxisType = columnType;
           currentxAxis = column;            
         }
@@ -619,7 +621,6 @@ ckan.module('visualize-data', function($) {
         var item = $(evt.item);
         var column = item.attr('data-column');
         var from = $(evt.from).attr('id');
-        isSupported = true;
         unsupportedContainer.addClass('hidden');
         if (columns[column]) {
           if (from === 'x-axis') {

--- a/ckanext/visualize/fanstatic/js/modules/visualize-data.js
+++ b/ckanext/visualize/fanstatic/js/modules/visualize-data.js
@@ -300,6 +300,7 @@ ckan.module('visualize-data', function($) {
           currentyAxis = column;
             
           if (
+            // Unsupported graph types
             (currentxAxisType === "text" && currentyAxisType === "text") ||
             (currentxAxisType === ("timestamp" || "date") &&
               currentyAxisType === ("timestamp" || "date")) ||
@@ -314,16 +315,6 @@ ckan.module('visualize-data', function($) {
             noChartContainer.removeClass('hidden');
             unsupportedContainer.removeClass('hidden');
             isSupported = false;
-            // chartData.labels = [];
-            // currentxAxisType = null;
-            // currentxAxis = null;
-            // chartData.datasets[0].data = [];
-            // currentyAxisType = null;
-            // currentyAxis = null;
-            // xAxisHiddenInput.val('');
-            // yAxisHiddenInput.val('');
-            // chart.destroy();
-            // initChart();
             }            
         }
         if (columns[column] && isSupported) {

--- a/ckanext/visualize/fanstatic/js/modules/visualize-data.js
+++ b/ckanext/visualize/fanstatic/js/modules/visualize-data.js
@@ -142,7 +142,7 @@ ckan.module('visualize-data', function($) {
     }
   }
 
-  function isUnsupportedGraphType(xAxisType, yAxisType) {
+  function isSupportedGraphType(xAxisType, yAxisType) {
     if (
       // Unsupported graph types
       (xAxisType === "text" && yAxisType === "text") ||
@@ -155,8 +155,8 @@ ckan.module('visualize-data', function($) {
       (xAxisType === "numeric" &&
         yAxisType === ("timestamp" || "date"))
     ) {
-      return true;
-    } else return false;
+      return false;
+    } else return true;
   }
 
   return {
@@ -311,7 +311,7 @@ ckan.module('visualize-data', function($) {
         var columnType = item.attr('data-column-type');
         var to = $(evt.to).attr('id');
         unsupportedContainer.addClass('hidden');
-        isSupported = false;
+        isSupported = true;
         if(to === 'y-axis') {
           currentyAxisType = columnType;
           currentyAxis = column;                   
@@ -320,13 +320,13 @@ ckan.module('visualize-data', function($) {
           currentxAxisType = columnType;
           currentxAxis = column;            
         }
-        isSupported = isUnsupportedGraphType(currentxAxisType, currentyAxisType);   
-        if(isSupported) {
+        isSupported = isSupportedGraphType(currentxAxisType, currentyAxisType);   
+        if(!isSupported) {
           chartContainer.addClass('hidden');
           noChartContainer.removeClass('hidden');
           unsupportedContainer.removeClass('hidden');
         }
-        if (columns[column] && !isSupported) {
+        if (columns[column] && isSupported) {
           if (to === 'x-axis') {
             lastxAxisEvent = { item: evt.item, to: evt.to };
             currentxAxisType = columnType;
@@ -619,7 +619,7 @@ ckan.module('visualize-data', function($) {
         var item = $(evt.item);
         var column = item.attr('data-column');
         var from = $(evt.from).attr('id');
-        isSupported = false;
+        isSupported = true;
         unsupportedContainer.addClass('hidden');
         if (columns[column]) {
           if (from === 'x-axis') {

--- a/ckanext/visualize/fanstatic/js/modules/visualize-data.js
+++ b/ckanext/visualize/fanstatic/js/modules/visualize-data.js
@@ -85,7 +85,7 @@ ckan.module('visualize-data', function($) {
       },
       legend: {
         position: 'bottom',
-        display: false       
+        display: false   
       }
     };
     chartData.datasets[0].backgroundColor = colorPalette[0];
@@ -297,8 +297,7 @@ ckan.module('visualize-data', function($) {
         isSupported = true;
         if(to === 'y-axis') {
           currentyAxisType = columnType;
-          currentyAxis = column;
-            
+          currentyAxis = column;            
           if (
             // Unsupported graph types
             (currentxAxisType === "text" && currentyAxisType === "text") ||

--- a/ckanext/visualize/fanstatic/js/modules/visualize-data.js
+++ b/ckanext/visualize/fanstatic/js/modules/visualize-data.js
@@ -379,6 +379,23 @@ ckan.module('visualize-data', function($) {
             lastyAxisEvent = { item: evt.item, to: evt.to };
             currentyAxisType = columnType;
             currentyAxis = column;
+            if (
+              (currentxAxisType === "text" && currentyAxisType === "text") ||
+              (currentxAxisType === ("timestamp" || "date") &&
+                currentyAxisType === ("timestamp" || "date")) ||
+              (currentxAxisType === "text" &&
+                currentyAxisType === ("timestamp" || "date")) ||
+              (currentxAxisType === ("timestamp" || "date") &&
+                currentyAxisType === "text") ||
+              (currentxAxisType === "numeric" &&
+                currentyAxisType === ("timestamp" || "date"))
+            ) {
+              alert("The chosen graph type is not supported! Please choose other values for X or Y axis.");
+              console.log(item);
+              currentyAxis = null;
+              currentyAxisType = null;
+              item.remove();
+            }
             currentChartType =
               getChartType(currentxAxisType, currentyAxisType) || 'bar';
 

--- a/ckanext/visualize/templates/snippets/visualize_view_show.html
+++ b/ckanext/visualize/templates/snippets/visualize_view_show.html
@@ -127,7 +127,7 @@
       <div class="chart-container hidden">
         <canvas id="chart-canvas"></canvas>
       </div>
-      <p class="unsupported hidden" style="color: red;">The requested graph type combination is currently not supported. Please try with another pill combination.</p>
+      <div class="unsupported hidden"><p style="color: red;">The requested graph type combination is currently not supported. Please try with another pill combination.</p></div>
       <div class="no-chart-container">
         <figure class="no-chart-illustration">
           <img src="/base/images/No-chart-illustration.png" class="img-responsive" alt="Illustration image" />

--- a/ckanext/visualize/templates/snippets/visualize_view_show.html
+++ b/ckanext/visualize/templates/snippets/visualize_view_show.html
@@ -46,8 +46,8 @@
 
               <div class="list-group-item column" data-column="{{ field.value }}" data-column-type="{{ field.type }}">
                 <span class="badge-pill column-pill" style="background-color: {{ column_color }};"><i
-                    class="fa {{ h.get_icon_for_data_type(field.type) }} fa-fw"
-                    aria-hidden="true"></i><span class="pill-title" title="{{ field.value }}">{{ field.value }}</span></span>
+                    class="fa {{ h.get_icon_for_data_type(field.type) }} fa-fw" aria-hidden="true"></i><span
+                    class="pill-title" title="{{ field.value }}">{{ field.value }}</span></span>
               </div>
               {% endfor %}
             </div>
@@ -127,8 +127,11 @@
       <div class="chart-container hidden">
         <canvas id="chart-canvas"></canvas>
       </div>
-      <div class="unsupported hidden"><p style="color: red;">The requested graph type combination is currently not supported. Please try with another pill combination.</p></div>
       <div class="no-chart-container">
+        <div class="chart-unsupported hidden alert alert-warning">
+          <i class="fa fa-warning fa-fw" aria-hidden="true"></i>
+          <span>{{ _('The requested graph type combination is currently not supported. Please try with another pill combination.') }}</span>
+        </div>
         <figure class="no-chart-illustration">
           <img src="/base/images/No-chart-illustration.png" class="img-responsive" alt="Illustration image" />
         </figure>

--- a/ckanext/visualize/templates/snippets/visualize_view_show.html
+++ b/ckanext/visualize/templates/snippets/visualize_view_show.html
@@ -127,6 +127,7 @@
       <div class="chart-container hidden">
         <canvas id="chart-canvas"></canvas>
       </div>
+      <p class="unsupported hidden">The graph type is currently not supported.</p>
       <div class="no-chart-container">
         <figure class="no-chart-illustration">
           <img src="/base/images/No-chart-illustration.png" class="img-responsive" alt="Illustration image" />

--- a/ckanext/visualize/templates/snippets/visualize_view_show.html
+++ b/ckanext/visualize/templates/snippets/visualize_view_show.html
@@ -127,7 +127,7 @@
       <div class="chart-container hidden">
         <canvas id="chart-canvas"></canvas>
       </div>
-      <p class="unsupported hidden">The graph type is currently not supported.</p>
+      <p class="unsupported hidden" style="color: red;">The requested graph type combination is currently not supported. Please try with another pill combination.</p>
       <div class="no-chart-container">
         <figure class="no-chart-illustration">
           <img src="/base/images/No-chart-illustration.png" class="img-responsive" alt="Illustration image" />


### PR DESCRIPTION
This PR introduces the following changes:
- Implement unsupported graph types, and display a message for the user when choosing an unsupported graph type.
Testing instructions:
1. Upload a resource
2. Go to Visualize data page
3. Choose one of the following graph type combinations for X and Y axis,:
- (x, y) = (text, text)
- (x, y) = (date, text)
- (x, y) = (text, date)
- (x, y) = (date, date)
- (x, y) = (numeric, date)
4. Drag & drop pills accordingly
The applied changes should generate the default chart illustration with a warning message.