### PR TITLE
Fixes error 'extras: The input field __extras was not expected.' when updating resource views.

### DIFF
--- a/ckanext/visualize/templates/package/edit_view.html
+++ b/ckanext/visualize/templates/package/edit_view.html
@@ -3,9 +3,11 @@
 {% block form %}
   <form class="dataset-form dataset-resource-form" method="post" data-module="basic-form resource-form">
     {% include 'package/snippets/view_form.html' %}
+    {% if resource_view.view_type == 'visualize' %}
     <input type="hidden" name="visualize_x_axis" />
     <input type="hidden" name="visualize_y_axis" />
     <input type="hidden" name="visualize_color_attr" />
+    {% endif %}
     <div class="form-actions">
       <button class="btn btn-danger pull-left" name="delete" value="Delete"> {{ _('Delete') }} </button>
       <button class="btn btn-default {% if not h.resource_view_display_preview(data) %}hide{%endif%}" name="preview" value="True" type="submit">{{ _('Preview') }}</button>

--- a/ckanext/visualize/templates/package/new_view.html
+++ b/ckanext/visualize/templates/package/new_view.html
@@ -12,9 +12,11 @@
 
   <form class="dataset-form dataset-resource-form" method="post" data-module="basic-form resource-form">
     {% include 'package/snippets/view_form.html' %}
+    {% if resource_view.view_type == 'visualize' %}
     <input type="hidden" name="visualize_x_axis" />
     <input type="hidden" name="visualize_y_axis" />
     <input type="hidden" name="visualize_color_attr" />
+    {% endif %}
     <div class="form-actions">
         <button class="btn btn-default {% if not h.resource_view_display_preview(data) %}hide{%endif%}" name="preview" value="True" type="submit">{{ _('Preview') }}</button>
         <button class="btn btn-primary" name="save" value="Save" type="submit">{% block save_button_text %}{{ _('Add') }}{% endblock %}</button>


### PR DESCRIPTION
Fixes the error `extras: The input field __extras was not expected.` when updating any view metadata when `visualize` extension in present. This happens for views that are **not** `visualize` view type.
Boils down to hidden fields being added in the view template for create/edit in view types that are not `visualize` and which do not update the base resource_view schema.

This PR adds check for the view type in the templates before adding the hidden fields.